### PR TITLE
Fix ipaddr parsing issue

### DIFF
--- a/logstash/40-fortigate_2_ecs
+++ b/logstash/40-fortigate_2_ecs
@@ -171,6 +171,7 @@ filter {
             copy =>{ "[filetype]"=> "[file][extension]" }
             copy =>{ "[fortios][group]"=> "[source][user][group][name]" }
             copy =>{ "[hostname]"=> "[url][domain]" }
+            split => { "ipaddr" => ", " }
             copy =>{ "[ipaddr]"=> "[dns][resolved_ip]" }
             
             copy =>{ "[msg]"=> "[message]" }


### PR DESCRIPTION
Fix the issue for when multiple values exist in ipaddr (as comma separated values) then split them into an array so that the destination field contains an array so that it can be ingested. Without this fix, it is possible you could be missing DNS events or events that have ipaddr containing more than 1 IP address.

https://github.com/enotspe/fortinet-2-elasticsearch/issues/9