### PR TITLE
Update 40-fortigate_2_ecs

### DIFF
--- a/logstash/40-fortigate_2_ecs
+++ b/logstash/40-fortigate_2_ecs
@@ -404,6 +404,23 @@ filter {
         }
     }
     
+    # ECS categorization fields for network transport from network protocol
+    if [network][protocol]  {
+        mutate {
+            lowercase => [ "[network][protocol]" ]
+        }
+        grok {
+            match => {
+                "[network][protocol]" => "(?<[network][transport]>(^tcp)|(^udp))"
+           }
+        }
+    }
+    if [network][transport] {
+        mutate {
+            remove_field => ["[network][protocol]"] 
+        }
+    }
+    
 }
 
 output {


### PR DESCRIPTION
I am seeing a lot of tcp/1234, TCP_3933, udp/1122, UDP/5533 as the data in the network protocol when I believe these should be collapsed down to network.transport : tcp or udp.

I am not sure TCP_3933 are really protocols but rather just ports?

This adjustment will ensure that network.protocol will contain: aol, rdp, ssh, telnet, etc.. by:

1. Lowercase network protocol for standardization and less regular expressions to match on in the next step.
2. If network.protocol starts with tcp or udp, add it to a new field called network.transport.
3. Remove the network.protocol field if the network.transport field exists. Out of all the data I have seen, network.protocol doesn't seem to exist, so this should work until someone can find a better way.

Let me know if this helps!