### PR TITLE
Update common_ecs.conf

### DIFF
--- a/logstash/conf.d/common_ecs.conf
+++ b/logstash/conf.d/common_ecs.conf
@@ -190,7 +190,7 @@ filter {
         fingerprint {
                 method => "SHA1"
             base64encode => "true"
-                source => ["[source][ip]","[detination][ip]","[source][port]","[destination][port]","[network][iana_number]"]
+                source => ["[source][ip]","[destination][ip]","[source][port]","[destination][port]","[network][iana_number]"]
             concatenate_sources => true
             target => "[network][community_id]"
         }


### PR DESCRIPTION
This improves network community id calculation, but it still seems broken, as seed and padding are not used and fields seem to be in wrong order.