### PR TITLE
Rename project to FLASI and repo to flasi

### DIFF
--- a/ELK/README.md
+++ b/ELK/README.md
@@ -1,6 +1,6 @@
 # ELK
 
-Elasticsearch configuration for FortiDragon — index templates, ingest pipelines, Kibana dashboards, and tooling to deploy them.
+Elasticsearch configuration for FLASI — index templates, ingest pipelines, Kibana dashboards, and tooling to deploy them.
 
 ## Folder structure
 

--- a/ELK/load.sh
+++ b/ELK/load.sh
@@ -52,7 +52,7 @@ VERBOSE="${VERBOSE:-false}"
 # END OF CONFIGURATION SECTION
 # ============================================================================
 
-echo "Welcome to the FortiDragon!"
+echo "Welcome to FLASI!"
 echo -e "\nThe best analytics tool for threat hunting with Fortinet logs"
 
 echo -e "\nHere's what this script does:"

--- a/ELK/logstash (deprecated)/conf.d/syslog-fortinet-fortigate_2_ecsv2.conf
+++ b/ELK/logstash (deprecated)/conf.d/syslog-fortinet-fortigate_2_ecsv2.conf
@@ -402,7 +402,7 @@ filter {
     }
 
 #   fortigate crash log. "msg" field is too big and creates ramdom fields
-#   https://github.com/enotspe/fortinet-2-elasticsearch/issues/4
+#   https://github.com/enotspe/flasi/issues/4
 #    if  [event][code] == "0100032546" {
 #        prune {
 #            whitelist_names => [ "^@timestamp$" , "observer", "organization", "event", "action", "ecs", "^subtype$" , "^type$" , "tags", "log" ]

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 <div align="center">
-  <img src="docs/assets/logos/logo_with_name_small.jpg" alt="FortiDragon Logo" />
+  <img src="docs/assets/logos/logo_with_name_small.jpg" alt="FLASI Logo" />
 
-  <h1>FortiDragon</h1>
+  <h1>FLASI</h1>
   <h2><strong>The Best Analytics Platform for Firewall Logs</strong></h2>
 
   <h3>
-    <a href="https://enotspe.github.io/fortinet-2-elasticsearch/">📚 Full Documentation</a> •
-    <a href="https://enotspe.github.io/fortinet-2-elasticsearch/installation/">🚀 Installation</a> •
-    <a href="https://enotspe.github.io/fortinet-2-elasticsearch/roadmap/">🛣️ Roadmap</a>
+    <a href="https://enotspe.github.io/flasi/">📚 Full Documentation</a> •
+    <a href="https://enotspe.github.io/flasi/installation/">🚀 Installation</a> •
+    <a href="https://enotspe.github.io/flasi/roadmap/">🛣️ Roadmap</a>
   </h3>
   
   [![Discord](https://img.shields.io/discord/753104553846505552?color=7289da&label=Discord&logo=discord&logoColor=white)](https://discord.gg/9qn4enV)
-  [![GitHub stars](https://img.shields.io/github/stars/enotspe/fortinet-2-elasticsearch?style=social)](https://github.com/enotspe/fortinet-2-elasticsearch/stargazers)
+  [![GitHub stars](https://img.shields.io/github/stars/enotspe/flasi?style=social)](https://github.com/enotspe/flasi/stargazers)
   [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
   
 </div>
 
 ---
 
-## 🎯 What is FortiDragon?
+## 🎯 What is FLASI?
 
 Tired of expensive SIEMs that don't understand firewall logs?
 
-**FortiDragon** is a full-featured analytics platform that transforms Fortinet (FortiGate, FortiEDR, FortiMail, FortiWeb) and Palo Alto PAN-OS logs into actionable threat intelligence without breaking the bank.
+**FLASI** is a full-featured analytics platform that transforms Fortinet (FortiGate, FortiEDR, FortiMail, FortiWeb) and Palo Alto PAN-OS logs into actionable threat intelligence without breaking the bank.
 
 After 10+ years fighting with overpriced SIEMs that treat firewall logs as an leftover checkbox in a datasheet, we built the platform we always needed.
 
@@ -72,13 +72,13 @@ Mix and match: Every layer is swappable. Use what works for your environment.
 
 All detailed documentation has moved to our dedicated documentation site:
 
-### **[📚 https://enotspe.github.io/fortinet-2-elasticsearch/](https://enotspe.github.io/fortinet-2-elasticsearch/)**
+### **[📚 https://enotspe.github.io/flasi/](https://enotspe.github.io/flasi/)**
 
-- **[Installation Guide](https://enotspe.github.io/fortinet-2-elasticsearch/installation/)** - Step-by-step setup for all components
-- **[Architecture](https://enotspe.github.io/fortinet-2-elasticsearch/architecture/)** - How FortiDragon works under the hood
-- **[Dashboards](https://enotspe.github.io/fortinet-2-elasticsearch/dashboards/)** - Dashboard structure and usage
-- **[Roadmap](https://enotspe.github.io/fortinet-2-elasticsearch/roadmap/)** - What's next for FortiDragon
-- **[Engage](https://enotspe.github.io/fortinet-2-elasticsearch/engage/)** - Join the community
+- **[Installation Guide](https://enotspe.github.io/flasi/installation/)** - Step-by-step setup for all components
+- **[Architecture](https://enotspe.github.io/flasi/architecture/)** - How FLASI works under the hood
+- **[Dashboards](https://enotspe.github.io/flasi/dashboards/)** - Dashboard structure and usage
+- **[Roadmap](https://enotspe.github.io/flasi/roadmap/)** - What's next for FLASI
+- **[Engage](https://enotspe.github.io/flasi/engage/)** - Join the community
 
 ## 🎨 Dashboard Preview
 
@@ -87,9 +87,9 @@ All detailed documentation has moved to our dedicated documentation site:
   <p><em>Navigate seamlessly through traffic, UTM, and event dashboards</em></p>
 </div>
 
-## 🌟 Why FortiDragon?
+## 🌟 Why FLASI?
 
-| Feature | Traditional SIEM | FortiDragon |
+| Feature | Traditional SIEM | FLASI |
 |---------|------------------|-------------|
 | **Cost** | $$$$$+ per GB | Free + your infrastructure |
 | **Firewall Focus** | Generic checkbox | Purpose-built |
@@ -103,17 +103,17 @@ All detailed documentation has moved to our dedicated documentation site:
 ### Get Help
 
 - 💬 [Join our Discord](https://discord.gg/9qn4enV) - Active community for questions and discussions
-- 📖 [Read the Docs](https://enotspe.github.io/fortinet-2-elasticsearch/) - Comprehensive guides
-- 🐛 [Report Issues](https://github.com/enotspe/fortinet-2-elasticsearch/issues) - Bug reports and feature requests
+- 📖 [Read the Docs](https://enotspe.github.io/flasi/) - Comprehensive guides
+- 🐛 [Report Issues](https://github.com/enotspe/flasi/issues) - Bug reports and feature requests
 
 ### Support the Project
 
 You're already saving thousands on SIEM costs. Consider giving back:
 
 - 💰 [Donate via PayPal](https://www.paypal.com/paypalme/fortidragon) - Support development
-- ⭐ [Star this repo](https://github.com/enotspe/fortinet-2-elasticsearch/stargazers) - Show your support
+- ⭐ [Star this repo](https://github.com/enotspe/flasi/stargazers) - Show your support
 - 📢 Share with colleagues - Spread the word
-- 🤝 [Contribute](https://enotspe.github.io/fortinet-2-elasticsearch/engage/#areas-for-contribution) - Code, docs, datasets
+- 🤝 [Contribute](https://enotspe.github.io/flasi/engage/#areas-for-contribution) - Code, docs, datasets
 
 ## 🗺️ Supported Platforms
 

--- a/docs/dashboards/datasets.md
+++ b/docs/dashboards/datasets.md
@@ -1,6 +1,6 @@
 # Datasets
 
-FortiDragon includes comprehensive datasets and field mappings for various Fortinet products.
+FLASI includes comprehensive datasets and field mappings for various Fortinet products.
 
 ## Available Datasets
 

--- a/docs/engage.md
+++ b/docs/engage.md
@@ -8,10 +8,10 @@ Feel free to ask about anything on the channel: support, questions, ideas, not o
 
 ## Help Us Grow
 
-If FortiDragon helps you:
+If FLASI helps you:
 
-- 💰 [Make a donation](https://www.paypal.com/paypalme/fortidragon). You are already saving a lot of money by using FortiDragon!
-- ⭐ [Star the repository](https://github.com/enotspe/fortinet-2-elasticsearch)
+- 💰 [Make a donation](https://www.paypal.com/paypalme/fortidragon). You are already saving a lot of money by using FLASI!
+- ⭐ [Star the repository](https://github.com/enotspe/flasi)
 - 📢 Share with colleagues
 - 🤝 [Contribute](#areas-for-contribution)
 
@@ -19,7 +19,7 @@ If FortiDragon helps you:
 
 If you find a bug or have a feature request:
 
-1. Check if the issue already exists in our [GitHub Issues](https://github.com/enotspe/fortinet-2-elasticsearch/issues)
+1. Check if the issue already exists in our [GitHub Issues](https://github.com/enotspe/flasi/issues)
 2. If not, create a new issue with:
    - Clear description of the problem or feature
    - Steps to reproduce (for bugs)
@@ -40,8 +40,8 @@ If you find a bug or have a feature request:
 
 1. Fork the repository
    ```bash
-   git clone https://github.com/enotspe/fortinet-2-elasticsearch.git
-   cd fortinet-2-elasticsearch
+   git clone https://github.com/enotspe/flasi.git
+   cd flasi
    ```
 
 2. Create a feature branch

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
 # Home
 
 <div align="center">
-    <img src="assets/logos/logo_with_name_small.jpg" alt="FortiDragon" />
+    <img src="assets/logos/logo_with_name_small.jpg" alt="FLASI" />
 </div>
 
-Welcome to **FortiDragon**! 
+Welcome to **FLASI**! 
 
 So you want to take your ~~Fortinet~~ firewalls logs (both Fortinet and Palo Alto) to ~~Elasticsearch~~ Victoria Logs, Elasticsearch and others??? You have come to the right place!!! 👍
 
@@ -12,7 +12,7 @@ We are the best analytics plataform for firewall logs. No kidding!!!
 
 ## How it all began
 
-We actually use FortiDragon on our day to day operations for threat hunting, so we understand all the painpoints of a security analyst. After 10+ years experience with Fortinet and Palo Alto we could not find a solution that could extract all the juice out of our logs. We tried several SIEMs along the way and found out that firewall logs are just a checkmark on their datasheets. Full parsing and performance tuning for such volume of logs was not carefully considered by any SIEM vendor. Finally we decided we needed to build a solution ourselves having some core principles: flexibility, performance and cost. That is why FortiDragon is by far the best option out there.
+We actually use FLASI on our day to day operations for threat hunting, so we understand all the painpoints of a security analyst. After 10+ years experience with Fortinet and Palo Alto we could not find a solution that could extract all the juice out of our logs. We tried several SIEMs along the way and found out that firewall logs are just a checkmark on their datasheets. Full parsing and performance tuning for such volume of logs was not carefully considered by any SIEM vendor. Finally we decided we needed to build a solution ourselves having some core principles: flexibility, performance and cost. That is why FLASI is by far the best option out there.
 
 ## Requeriments
 
@@ -33,7 +33,7 @@ More important than what you need is what you dont need.
 
 If you feel related to the previous statements, we got you covered.
 
-If you are Splunk, QRadar, or [Elastic Serverless](https://www.elastic.co/pricing/serverless-search) users, you are welcome to stay and make a [contribution](engage.md#help-us-grow) to support FortiDragon. You will get more value out of your 💵 here.
+If you are Splunk, QRadar, or [Elastic Serverless](https://www.elastic.co/pricing/serverless-search) users, you are welcome to stay and make a [contribution](engage.md#help-us-grow) to support FLASI. You will get more value out of your 💵 here.
 
 ## The Challenge
 
@@ -99,7 +99,7 @@ Splunk charges per GB ingested. Elastic Serverless makes you cry when you see th
 
 Until now.
 
-## FortiDragon Difference
+## FLASI Difference
 
 We had one core constraint: **No money.** 💰🚫
 
@@ -150,7 +150,7 @@ That's why we made it **super simple** to spin up:
 
 ## Installation
 
-Ready to get started? Check out our [Installation Guide](installation/index.md) to begin your FortiDragon journey!
+Ready to get started? Check out our [Installation Guide](installation/index.md) to begin your FLASI journey!
 
 
 ## Authors
@@ -165,9 +165,9 @@ Current maintenance and development [@enotspe](https://github.com/enotspe) 🐉
 
 ## Support the Project
 
-If FortiDragon helps you:
+If FLASI helps you:
 
-- 💰 [Make a donation](https://www.paypal.com/paypalme/fortidragon). You are already saving a lot of money by using FortiDragon!
-- ⭐ [Star the repository](https://github.com/enotspe/fortinet-2-elasticsearch)
+- 💰 [Make a donation](https://www.paypal.com/paypalme/fortidragon). You are already saving a lot of money by using FLASI!
+- ⭐ [Star the repository](https://github.com/enotspe/flasi)
 - 📢 Share with colleagues
 - 🤝 [Contribute](engage.md/#areas-for-contribution)

--- a/docs/installation/datasource/fortigate.md
+++ b/docs/installation/datasource/fortigate.md
@@ -1,6 +1,6 @@
 # Fortigate
 
-This guide covers how to configure your Fortigate firewall to send syslog data to FortiDragon.
+This guide covers how to configure your Fortigate firewall to send syslog data to FLASI.
 
 ## Syslog Configuration
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -2,7 +2,7 @@
 
 Let's get this party started! 🤩
 
-FortiDragon uses a modular [architecture](../architecture.md) where each layer is independent. Choose the technologies that best fit your needs.
+FLASI uses a modular [architecture](../architecture.md) where each layer is independent. Choose the technologies that best fit your needs.
 
 
 ## Installation Flow
@@ -137,7 +137,7 @@ After completing installation, you'll have:
 ## Need Help?
 
 - 💬 **Community Support:** [Discord](https://discord.gg/9qn4enV)
-- 🐛 **Report Issues:** [GitHub Issues](https://github.com/enotspe/fortinet-2-elasticsearch/issues)
+- 🐛 **Report Issues:** [GitHub Issues](https://github.com/enotspe/flasi/issues)
 - 🗺️ **Future Plans:** [Roadmap](../roadmap.md)
 
 

--- a/docs/installation/ingest/logstash.md
+++ b/docs/installation/ingest/logstash.md
@@ -22,8 +22,8 @@ echo HOSTNAME=\""$HOSTNAME"\" | sudo tee  -a /etc/default/logstash
 cd /usr/share/logstash
 sudo bin/logstash-plugin install logstash-filter-tld
 ```
-5. Copy [pipelines.yml](https://github.com/enotspe/fortinet-2-elasticsearch/blob/master/logstash/pipelines.yml) to your logstash folder.
-6. Copy [conf.d](https://github.com/enotspe/fortinet-2-elasticsearch/tree/master/logstash/conf.d) content to your conf.d folder.
+5. Copy [pipelines.yml](https://github.com/enotspe/flasi/blob/master/logstash/pipelines.yml) to your logstash folder.
+6. Copy [conf.d](https://github.com/enotspe/flasi/tree/master/logstash/conf.d) content to your conf.d folder.
 7. [Start logstash](https://www.elastic.co/guide/en/logstash/current/running-logstash.html)
 
 

--- a/docs/installation/ingest/vector.md
+++ b/docs/installation/ingest/vector.md
@@ -1,6 +1,6 @@
 # Vector
 
-This page covers Vector configuration for FortiDragon, based on the existing vector documentation.
+This page covers Vector configuration for FLASI, based on the existing vector documentation.
 
 ## Install as a service
 
@@ -8,7 +8,7 @@ There are many ways for [installing Vector](https://vector.dev/docs/setup/instal
 
 ## Load multiple confif files
 
-We have split Vector config [files](https://github.com/enotspe/fortinet-2-elasticsearch/tree/main/vector) by plattaform, so FortiDragon Vector directory should look like:
+We have split Vector config [files](https://github.com/enotspe/flasi/tree/main/vector) by plattaform, so FLASI Vector directory should look like:
 
 ```
 /etc/vector/
@@ -52,7 +52,7 @@ sudo systemctl restart vector
 
 ## Environment Variables
 
-FortiDragon Vector config files uses envioremental variables for passing specific values for your setup. All variables have defaults values in the config files.
+FLASI Vector config files uses envioremental variables for passing specific values for your setup. All variables have defaults values in the config files.
 
 `INTERNAL_NETWORKS` is the only variable that must be set.
 

--- a/docs/installation/storage/elasticsearch.md
+++ b/docs/installation/storage/elasticsearch.md
@@ -2,7 +2,7 @@
 
 We got a script!!!! 🎉
 
-FortiDragon provides an automated script to set up all necessary Elasticsearch components.
+FLASI provides an automated script to set up all necessary Elasticsearch components.
 
 ## Prerequisites
 
@@ -15,8 +15,8 @@ FortiDragon provides an automated script to set up all necessary Elasticsearch c
 1. **Clone the repository**:
 
    ```bash
-   git clone https://github.com/enotspe/fortinet-2-elasticsearch.git
-   cd fortinet-2-elasticsearch/ELK
+   git clone https://github.com/enotspe/flasi.git
+   cd flasi/ELK
    ```
 
 2. **Configure your environment**:

--- a/docs/installation/viz/grafana.md
+++ b/docs/installation/viz/grafana.md
@@ -56,7 +56,7 @@ grafana-cli plugins install esnet-chord-panel
 
 ## Import Dashboards
 
-[Import](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/#import-a-dashboard) Grafana dashboards from [here](https://github.com/enotspe/fortinet-2-elasticsearch/tree/main/grafana)
+[Import](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/#import-a-dashboard) Grafana dashboards from [here](https://github.com/enotspe/flasi/tree/main/grafana)
 
 Currently, v2 Dashboards can not be uploaded to [Dashboards page](https://grafana.com/grafana/dashboards/).
 

--- a/docs/installation/viz/kibana.md
+++ b/docs/installation/viz/kibana.md
@@ -3,7 +3,7 @@
 In Kibana:
 
 1. **Navigate to Saved Objects**: Go to Management → Stack Management → Saved Objects
-2. **Import dashboards**: Click "Import" and select the dashboard files from the [here](https://github.com/enotspe/fortinet-2-elasticsearch/tree/main/ELK/kibana)
+2. **Import dashboards**: Click "Import" and select the dashboard files from the [here](https://github.com/enotspe/flasi/tree/main/ELK/kibana)
 
 **Hopefully you should be dancing with your logs by now.** 🕺💃
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ As we discussed previously on [The Challenge](index.md#the-challenge), we need t
 
 ### **The new ~~5~~ 4-tupple**
 
-Firewall [datasets](https://github.com/enotspe/fortinet-2-elasticsearch/tree/main/datasets/Fortinet/Fortigate/7.6/unique_fields) contain over 200 fields. We can't pivot on all of them.
+Firewall [datasets](https://github.com/enotspe/flasi/tree/main/datasets/Fortinet/Fortigate/7.6/unique_fields) contain over 200 fields. We can't pivot on all of them.
 
 We need to choose **core anchors** that become the foundation for our analysis.
 
@@ -351,6 +351,6 @@ Honestly? We don't know.
 
 We're a [solo](engage.md#help-us-grow) team working on this in our spare time because we're tired of the current state of security tooling. Some of these features might take months. Some might take years. Some might prove to be dead ends.
 
-But we're committed to the journey. Every commit gets us closer. Every contributor accelerates the timeline. Every user who deploys FortiDragon validates that this problem is worth solving.
+But we're committed to the journey. Every commit gets us closer. Every contributor accelerates the timeline. Every user who deploys FLASI validates that this problem is worth solving.
 
 **Want to make it go faster?** [Engage](engage.md), [help us grow](engage.md#help-us-grow), or just spread the word. 🚀

--- a/grafana/Fortigate/log fields.json
+++ b/grafana/Fortigate/log fields.json
@@ -54,7 +54,7 @@
                                                 "root_selector": "",
                                                 "source": "url",
                                                 "type": "csv",
-                                                "url": "https://raw.githubusercontent.com/enotspe/fortinet-2-elasticsearch/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_traffic_7_6.csv",
+                                                "url": "https://raw.githubusercontent.com/enotspe/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_traffic_7_6.csv",
                                                 "url_options": {
                                                     "data": "",
                                                     "method": "GET"
@@ -167,7 +167,7 @@
                                                 "root_selector": "",
                                                 "source": "url",
                                                 "type": "csv",
-                                                "url": "https://raw.githubusercontent.com/enotspe/fortinet-2-elasticsearch/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_utm_7_6.csv",
+                                                "url": "https://raw.githubusercontent.com/enotspe/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_utm_7_6.csv",
                                                 "url_options": {
                                                     "data": "",
                                                     "method": "GET"
@@ -280,7 +280,7 @@
                                                 "root_selector": "",
                                                 "source": "url",
                                                 "type": "csv",
-                                                "url": "https://raw.githubusercontent.com/enotspe/fortinet-2-elasticsearch/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_event_7_6.csv",
+                                                "url": "https://raw.githubusercontent.com/enotspe/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_event_7_6.csv",
                                                 "url_options": {
                                                     "data": "",
                                                     "method": "GET"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
-site_name: FortiDragon Documentation
+site_name: FLASI Documentation
 site_description: Network Security Logs Analytics
 site_author: Dragon
-site_url: https://enotspe.github.io/fortinet-2-elasticsearch/
+site_url: https://enotspe.github.io/flasi/
 
-repo_name: enotspe/fortinet-2-elasticsearch
-repo_url: https://github.com/enotspe/fortinet-2-elasticsearch
+repo_name: enotspe/flasi
+repo_url: https://github.com/enotspe/flasi
 edit_uri: edit/main/docs/
 
 theme:
@@ -153,7 +153,7 @@ extra:
   #generator: false # Hide "Made with Material for MkDocs" notice on the footer
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/enotspe/fortinet-2-elasticsearch
+      link: https://github.com/enotspe/flasi
     - icon: fontawesome/brands/discord
       link: https://discord.gg/9qn4enV
   version:


### PR DESCRIPTION
## Summary

- Replaces all references to `FortiDragon` with `FLASI` (Firewall Logs Analytics and Security Insights) across docs, scripts, and configs
- Updates all URLs from `enotspe/fortinet-2-elasticsearch` to `enotspe/flasi` (GitHub, GitHub Pages, raw.githubusercontent.com)
- Renames repo on GitHub from `fortinet-2-elasticsearch` to `flasi`

## Test plan

- [ ] Verify GitHub Pages redeploys correctly at `enotspe.github.io/flasi/`
- [ ] Confirm all internal doc links resolve after Pages rebuild
- [ ] Check Grafana dashboard CSV URLs load from the new raw.githubusercontent.com paths
- [ ] Update local git remote: `git remote set-url origin https://github.com/enotspe/flasi.git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)