### PR TITLE
Rename GitHub username from enotspe to dr4gon123

### DIFF
--- a/ELK/elasticsearch_mappings.py
+++ b/ELK/elasticsearch_mappings.py
@@ -6,7 +6,7 @@ Fetches unique_fields CSVs from the flores GitHub repository and generates
 Elasticsearch component templates that can be uploaded via API.
 
 Environment variables:
-  FLORES_REPO   - GitHub repo in "owner/name" format (default: enotspe/flores)
+  FLORES_REPO   - GitHub repo in "owner/name" format (default: dr4gon123/flores)
   FLORES_BRANCH - Branch to fetch from (default: main)
 """
 
@@ -19,7 +19,7 @@ import pandas as pd
 import requests
 
 
-FLORES_REPO = os.environ.get("FLORES_REPO", "enotspe/flores")
+FLORES_REPO = os.environ.get("FLORES_REPO", "dr4gon123/flores")
 FLORES_BRANCH = os.environ.get("FLORES_BRANCH", "main")
 
 GITHUB_API_BASE = f"https://api.github.com/repos/{FLORES_REPO}/contents"

--- a/ELK/logstash (deprecated)/conf.d/syslog-fortinet-fortigate_2_ecsv2.conf
+++ b/ELK/logstash (deprecated)/conf.d/syslog-fortinet-fortigate_2_ecsv2.conf
@@ -402,7 +402,7 @@ filter {
     }
 
 #   fortigate crash log. "msg" field is too big and creates ramdom fields
-#   https://github.com/enotspe/flasi/issues/4
+#   https://github.com/dr4gon123/flasi/issues/4
 #    if  [event][code] == "0100032546" {
 #        prune {
 #            whitelist_names => [ "^@timestamp$" , "observer", "organization", "event", "action", "ecs", "^subtype$" , "^type$" , "tags", "log" ]

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
   <h2><strong>The Best Analytics Platform for Firewall Logs</strong></h2>
 
   <h3>
-    <a href="https://enotspe.github.io/flasi/">📚 Full Documentation</a> •
-    <a href="https://enotspe.github.io/flasi/installation/">🚀 Installation</a> •
-    <a href="https://enotspe.github.io/flasi/roadmap/">🛣️ Roadmap</a>
+    <a href="https://dr4gon123.github.io/flasi/">📚 Full Documentation</a> •
+    <a href="https://dr4gon123.github.io/flasi/installation/">🚀 Installation</a> •
+    <a href="https://dr4gon123.github.io/flasi/roadmap/">🛣️ Roadmap</a>
   </h3>
   
   [![Discord](https://img.shields.io/discord/753104553846505552?color=7289da&label=Discord&logo=discord&logoColor=white)](https://discord.gg/9qn4enV)
-  [![GitHub stars](https://img.shields.io/github/stars/enotspe/flasi?style=social)](https://github.com/enotspe/flasi/stargazers)
+  [![GitHub stars](https://img.shields.io/github/stars/dr4gon123/flasi?style=social)](https://github.com/dr4gon123/flasi/stargazers)
   [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
   
 </div>
@@ -72,13 +72,13 @@ Mix and match: Every layer is swappable. Use what works for your environment.
 
 All detailed documentation has moved to our dedicated documentation site:
 
-### **[📚 https://enotspe.github.io/flasi/](https://enotspe.github.io/flasi/)**
+### **[📚 https://dr4gon123.github.io/flasi/](https://dr4gon123.github.io/flasi/)**
 
-- **[Installation Guide](https://enotspe.github.io/flasi/installation/)** - Step-by-step setup for all components
-- **[Architecture](https://enotspe.github.io/flasi/architecture/)** - How FLASI works under the hood
-- **[Dashboards](https://enotspe.github.io/flasi/dashboards/)** - Dashboard structure and usage
-- **[Roadmap](https://enotspe.github.io/flasi/roadmap/)** - What's next for FLASI
-- **[Engage](https://enotspe.github.io/flasi/engage/)** - Join the community
+- **[Installation Guide](https://dr4gon123.github.io/flasi/installation/)** - Step-by-step setup for all components
+- **[Architecture](https://dr4gon123.github.io/flasi/architecture/)** - How FLASI works under the hood
+- **[Dashboards](https://dr4gon123.github.io/flasi/dashboards/)** - Dashboard structure and usage
+- **[Roadmap](https://dr4gon123.github.io/flasi/roadmap/)** - What's next for FLASI
+- **[Engage](https://dr4gon123.github.io/flasi/engage/)** - Join the community
 
 ## 🎨 Dashboard Preview
 
@@ -103,17 +103,17 @@ All detailed documentation has moved to our dedicated documentation site:
 ### Get Help
 
 - 💬 [Join our Discord](https://discord.gg/9qn4enV) - Active community for questions and discussions
-- 📖 [Read the Docs](https://enotspe.github.io/flasi/) - Comprehensive guides
-- 🐛 [Report Issues](https://github.com/enotspe/flasi/issues) - Bug reports and feature requests
+- 📖 [Read the Docs](https://dr4gon123.github.io/flasi/) - Comprehensive guides
+- 🐛 [Report Issues](https://github.com/dr4gon123/flasi/issues) - Bug reports and feature requests
 
 ### Support the Project
 
 You're already saving thousands on SIEM costs. Consider giving back:
 
 - 💰 [Donate via PayPal](https://www.paypal.com/paypalme/fortidragon) - Support development
-- ⭐ [Star this repo](https://github.com/enotspe/flasi/stargazers) - Show your support
+- ⭐ [Star this repo](https://github.com/dr4gon123/flasi/stargazers) - Show your support
 - 📢 Share with colleagues - Spread the word
-- 🤝 [Contribute](https://enotspe.github.io/flasi/engage/#areas-for-contribution) - Code, docs, datasets
+- 🤝 [Contribute](https://dr4gon123.github.io/flasi/engage/#areas-for-contribution) - Code, docs, datasets
 
 ## 🗺️ Supported Platforms
 
@@ -147,6 +147,6 @@ Apache-2.0 license - See [LICENSE](LICENSE) for details
 
 ## 👥 Authors
 
-- Logstash pipelines, Elasticsearch config: [@hoat23](https://github.com/hoat23) & [@enotspe](https://github.com/enotspe)
-- Datasets, Kibana/Grafana dashboards, Vector pipelines, Victoria Logs: [@enotspe](https://github.com/enotspe)
-- Current maintenance and development: [@enotspe](https://github.com/enotspe)
+- Logstash pipelines, Elasticsearch config: [@hoat23](https://github.com/hoat23) & [@dr4gon123](https://github.com/dr4gon123)
+- Datasets, Kibana/Grafana dashboards, Vector pipelines, Victoria Logs: [@dr4gon123](https://github.com/dr4gon123)
+- Current maintenance and development: [@dr4gon123](https://github.com/dr4gon123)

--- a/docs/engage.md
+++ b/docs/engage.md
@@ -11,7 +11,7 @@ Feel free to ask about anything on the channel: support, questions, ideas, not o
 If FLASI helps you:
 
 - 💰 [Make a donation](https://www.paypal.com/paypalme/fortidragon). You are already saving a lot of money by using FLASI!
-- ⭐ [Star the repository](https://github.com/enotspe/flasi)
+- ⭐ [Star the repository](https://github.com/dr4gon123/flasi)
 - 📢 Share with colleagues
 - 🤝 [Contribute](#areas-for-contribution)
 
@@ -19,7 +19,7 @@ If FLASI helps you:
 
 If you find a bug or have a feature request:
 
-1. Check if the issue already exists in our [GitHub Issues](https://github.com/enotspe/flasi/issues)
+1. Check if the issue already exists in our [GitHub Issues](https://github.com/dr4gon123/flasi/issues)
 2. If not, create a new issue with:
    - Clear description of the problem or feature
    - Steps to reproduce (for bugs)
@@ -40,7 +40,7 @@ If you find a bug or have a feature request:
 
 1. Fork the repository
    ```bash
-   git clone https://github.com/enotspe/flasi.git
+   git clone https://github.com/dr4gon123/flasi.git
    cd flasi
    ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,11 +155,11 @@ Ready to get started? Check out our [Installation Guide](installation/index.md) 
 
 ## Authors
 
-Logstash pipelines and Elasticsearch config [@hoat23](https://github.com/hoat23) and [@enotspe](https://github.com/enotspe) 🐉
+Logstash pipelines and Elasticsearch config [@hoat23](https://github.com/hoat23) and [@dr4gon123](https://github.com/dr4gon123) 🐉
 
-Dataset analysis, Kibana and Grafana dashboards, Vector pipelines, Victoria Logs [@enotspe](https://github.com/enotspe) 🐉
+Dataset analysis, Kibana and Grafana dashboards, Vector pipelines, Victoria Logs [@dr4gon123](https://github.com/dr4gon123) 🐉
 
-Current maintenance and development [@enotspe](https://github.com/enotspe) 🐉
+Current maintenance and development [@dr4gon123](https://github.com/dr4gon123) 🐉
 
 ---
 
@@ -168,6 +168,6 @@ Current maintenance and development [@enotspe](https://github.com/enotspe) 🐉
 If FLASI helps you:
 
 - 💰 [Make a donation](https://www.paypal.com/paypalme/fortidragon). You are already saving a lot of money by using FLASI!
-- ⭐ [Star the repository](https://github.com/enotspe/flasi)
+- ⭐ [Star the repository](https://github.com/dr4gon123/flasi)
 - 📢 Share with colleagues
 - 🤝 [Contribute](engage.md/#areas-for-contribution)

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -137,7 +137,7 @@ After completing installation, you'll have:
 ## Need Help?
 
 - 💬 **Community Support:** [Discord](https://discord.gg/9qn4enV)
-- 🐛 **Report Issues:** [GitHub Issues](https://github.com/enotspe/flasi/issues)
+- 🐛 **Report Issues:** [GitHub Issues](https://github.com/dr4gon123/flasi/issues)
 - 🗺️ **Future Plans:** [Roadmap](../roadmap.md)
 
 

--- a/docs/installation/ingest/logstash.md
+++ b/docs/installation/ingest/logstash.md
@@ -22,8 +22,8 @@ echo HOSTNAME=\""$HOSTNAME"\" | sudo tee  -a /etc/default/logstash
 cd /usr/share/logstash
 sudo bin/logstash-plugin install logstash-filter-tld
 ```
-5. Copy [pipelines.yml](https://github.com/enotspe/flasi/blob/master/logstash/pipelines.yml) to your logstash folder.
-6. Copy [conf.d](https://github.com/enotspe/flasi/tree/master/logstash/conf.d) content to your conf.d folder.
+5. Copy [pipelines.yml](https://github.com/dr4gon123/flasi/blob/master/logstash/pipelines.yml) to your logstash folder.
+6. Copy [conf.d](https://github.com/dr4gon123/flasi/tree/master/logstash/conf.d) content to your conf.d folder.
 7. [Start logstash](https://www.elastic.co/guide/en/logstash/current/running-logstash.html)
 
 

--- a/docs/installation/ingest/vector.md
+++ b/docs/installation/ingest/vector.md
@@ -8,7 +8,7 @@ There are many ways for [installing Vector](https://vector.dev/docs/setup/instal
 
 ## Load multiple confif files
 
-We have split Vector config [files](https://github.com/enotspe/flasi/tree/main/vector) by plattaform, so FLASI Vector directory should look like:
+We have split Vector config [files](https://github.com/dr4gon123/flasi/tree/main/vector) by plattaform, so FLASI Vector directory should look like:
 
 ```
 /etc/vector/

--- a/docs/installation/storage/elasticsearch.md
+++ b/docs/installation/storage/elasticsearch.md
@@ -15,7 +15,7 @@ FLASI provides an automated script to set up all necessary Elasticsearch compone
 1. **Clone the repository**:
 
    ```bash
-   git clone https://github.com/enotspe/flasi.git
+   git clone https://github.com/dr4gon123/flasi.git
    cd flasi/ELK
    ```
 

--- a/docs/installation/viz/grafana.md
+++ b/docs/installation/viz/grafana.md
@@ -56,7 +56,7 @@ grafana-cli plugins install esnet-chord-panel
 
 ## Import Dashboards
 
-[Import](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/#import-a-dashboard) Grafana dashboards from [here](https://github.com/enotspe/flasi/tree/main/grafana)
+[Import](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/#import-a-dashboard) Grafana dashboards from [here](https://github.com/dr4gon123/flasi/tree/main/grafana)
 
 Currently, v2 Dashboards can not be uploaded to [Dashboards page](https://grafana.com/grafana/dashboards/).
 

--- a/docs/installation/viz/kibana.md
+++ b/docs/installation/viz/kibana.md
@@ -3,7 +3,7 @@
 In Kibana:
 
 1. **Navigate to Saved Objects**: Go to Management → Stack Management → Saved Objects
-2. **Import dashboards**: Click "Import" and select the dashboard files from the [here](https://github.com/enotspe/flasi/tree/main/ELK/kibana)
+2. **Import dashboards**: Click "Import" and select the dashboard files from the [here](https://github.com/dr4gon123/flasi/tree/main/ELK/kibana)
 
 **Hopefully you should be dancing with your logs by now.** 🕺💃
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,7 +46,7 @@ As we discussed previously on [The Challenge](index.md#the-challenge), we need t
 
 ### **The new ~~5~~ 4-tupple**
 
-Firewall [datasets](https://github.com/enotspe/flasi/tree/main/datasets/Fortinet/Fortigate/7.6/unique_fields) contain over 200 fields. We can't pivot on all of them.
+Firewall [datasets](https://github.com/dr4gon123/flasi/tree/main/datasets/Fortinet/Fortigate/7.6/unique_fields) contain over 200 fields. We can't pivot on all of them.
 
 We need to choose **core anchors** that become the foundation for our analysis.
 

--- a/grafana/Fortigate/log fields.json
+++ b/grafana/Fortigate/log fields.json
@@ -54,7 +54,7 @@
                                                 "root_selector": "",
                                                 "source": "url",
                                                 "type": "csv",
-                                                "url": "https://raw.githubusercontent.com/enotspe/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_traffic_7_6.csv",
+                                                "url": "https://raw.githubusercontent.com/dr4gon123/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_traffic_7_6.csv",
                                                 "url_options": {
                                                     "data": "",
                                                     "method": "GET"
@@ -167,7 +167,7 @@
                                                 "root_selector": "",
                                                 "source": "url",
                                                 "type": "csv",
-                                                "url": "https://raw.githubusercontent.com/enotspe/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_utm_7_6.csv",
+                                                "url": "https://raw.githubusercontent.com/dr4gon123/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_utm_7_6.csv",
                                                 "url_options": {
                                                     "data": "",
                                                     "method": "GET"
@@ -280,7 +280,7 @@
                                                 "root_selector": "",
                                                 "source": "url",
                                                 "type": "csv",
-                                                "url": "https://raw.githubusercontent.com/enotspe/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_event_7_6.csv",
+                                                "url": "https://raw.githubusercontent.com/dr4gon123/flasi/refs/heads/main/datasets/Fortinet/Fortigate/7.6/unique_fields/unique_log_fields_data_types_event_7_6.csv",
                                                 "url_options": {
                                                     "data": "",
                                                     "method": "GET"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: FLASI Documentation
 site_description: Network Security Logs Analytics
 site_author: Dragon
-site_url: https://enotspe.github.io/flasi/
+site_url: https://dr4gon123.github.io/flasi/
 
-repo_name: enotspe/flasi
-repo_url: https://github.com/enotspe/flasi
+repo_name: dr4gon123/flasi
+repo_url: https://github.com/dr4gon123/flasi
 edit_uri: edit/main/docs/
 
 theme:
@@ -153,7 +153,7 @@ extra:
   #generator: false # Hide "Made with Material for MkDocs" notice on the footer
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/enotspe/flasi
+      link: https://github.com/dr4gon123/flasi
     - icon: fontawesome/brands/discord
       link: https://discord.gg/9qn4enV
   version:


### PR DESCRIPTION
## Summary

- Updated all references to the GitHub username `enotspe` to `dr4gon123` across the repository
- Affects URLs, repo links, author credits, and config defaults in 14 files

## Test plan

- [ ] Verify docs site URLs resolve correctly after GitHub Pages republishes
- [ ] Verify GitHub links in README point to the correct repo/profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)