### PR TITLE
ci(docs): only trigger docs workflow on docs-related changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,18 @@ name: Deploy MkDocs to GitHub Pages
 on:
   push:
     branches: [main, master]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements.txt"
+      - ".github/workflows/docs.yml"
   pull_request:
     branches: [main, master]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements.txt"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Added `paths` filters to the `push` and `pull_request` triggers in `docs.yml`
- Workflow now only runs when `docs/**`, `mkdocs.yml`, `requirements.txt`, or the workflow file itself changes
- `workflow_dispatch` kept for manual triggering

## Test plan
- [ ] Verify a non-docs commit does not trigger the workflow
- [ ] Verify a change under `docs/` or `mkdocs.yml` does trigger the workflow
- [ ] Verify manual dispatch still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)