### PR TITLE
fix(elk): update flores CSV paths to new repository structure

### DIFF
--- a/ELK/README.md
+++ b/ELK/README.md
@@ -99,7 +99,7 @@ python elasticsearch_mappings.py
 ### What it does
 
 1. Queries the flores GitHub API to discover all available version directories (`7.2`, `7.4`, `7.6`, …)
-2. For each version and log type (`traffic`, `event`, `utm`), fetches the corresponding `unique_log_fields_data_types_<type>_<ver>.csv`
+2. For each version and log type (`traffic`, `event`, `utm`), fetches the corresponding `<type>_fields.csv` from `<version>/fields/`
 3. Maps CSV data types to Elasticsearch types:
    - `string` → `keyword`
    - `ip` → `ip`

--- a/ELK/elasticsearch_mappings.py
+++ b/ELK/elasticsearch_mappings.py
@@ -93,10 +93,8 @@ def discover_versions():
 
 
 def fetch_csv(version, log_type):
-    """Fetch a unique_fields CSV for the given version and log_type."""
-    version_suffix = version.replace(".", "_")
-    filename = f"unique_log_fields_data_types_{log_type}_{version_suffix}.csv"
-    url = f"{RAW_BASE}/{version}/unique_fields/{filename}"
+    """Fetch a fields CSV for the given version and log_type."""
+    url = f"{RAW_BASE}/{version}/fields/{log_type}_fields.csv"
     resp = requests.get(url, timeout=30)
     resp.raise_for_status()
     return pd.read_csv(io.StringIO(resp.text))


### PR DESCRIPTION
## Summary

- `fetch_csv()` in `elasticsearch_mappings.py` now requests `<version>/fields/<type>_fields.csv` instead of the old `<version>/unique_fields/unique_log_fields_data_types_<type>_<ver>.csv`
- Drops the now-unused `version_suffix` local variable in `fetch_csv()`
- Updates the README description to match the new filename pattern

## Test plan

- [ ] Verified all six combinations (versions 7.2, 7.4, 7.6 × types traffic, event, utm) resolve correctly via HTTP 200 with expected column headers (`Log Field Name`, `Data Type`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)