### PR TITLE
docs: convert README header from HTML to vanilla Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,13 @@
-<div align="center">
-  <img src="docs/assets/logos/logo_with_name_small.jpg" alt="FLASI Logo" />
+![FLASI Logo](docs/src/assets/logos/logo.jpeg)
 
-  <h1>FLASI — Firewall Log Analytics for Security Insights</h1>
-  <h2><strong>The Best Analytics Platform for Firewall Logs</strong></h2>
+# FLASI — Firewall Log Analytics for Security Insights
+## **The Best Analytics Platform for Firewall Logs**
 
-  <h3>
-    <a href="https://dr4gon123.github.io/flasi/">📚 Full Documentation</a> •
-    <a href="https://dr4gon123.github.io/flasi/installation/">🚀 Installation</a> •
-    <a href="https://dr4gon123.github.io/flasi/roadmap/">🛣️ Roadmap</a>
-  </h3>
-  
-  [![Discord](https://img.shields.io/discord/753104553846505552?color=7289da&label=Discord&logo=discord&logoColor=white)](https://discord.gg/phKD42uFUH)
-  [![GitHub stars](https://img.shields.io/github/stars/dr4gon123/flasi?style=social)](https://github.com/dr4gon123/flasi/stargazers)
-  [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
-  
-</div>
+[📚 Full Documentation](https://dr4gon123.github.io/flasi/) • [🚀 Installation](https://dr4gon123.github.io/flasi/installation/) • [🛣️ Roadmap](https://dr4gon123.github.io/flasi/roadmap/)
+
+[![Discord](https://img.shields.io/discord/753104553846505552?color=7289da&label=Discord&logo=discord&logoColor=white)](https://discord.gg/phKD42uFUH)
+[![GitHub stars](https://img.shields.io/github/stars/dr4gon123/flasi?style=social)](https://github.com/dr4gon123/flasi/stargazers)
+[![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE)
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace `<div align="center">` HTML block with standard Markdown syntax
- Fix broken logo path (`docs/assets/` → `docs/src/assets/logos/logo.jpeg`)
- Header is now left-aligned (vanilla Markdown has no centering support)

## Test plan

- [ ] View rendered README on GitHub and confirm logo loads correctly
- [ ] Confirm heading hierarchy (`#`, `##`) renders as expected
- [ ] Confirm nav links and badges render and are clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)