### PR TITLE
Add | filter -<sort_field>:NaN to barchart and timeseries panels

### DIFF
--- a/grafana/dev/FortiGate/traffic-fortios.json
+++ b/grafana/dev/FortiGate/traffic-fortios.json
@@ -13,7 +13,7 @@
           "enable": true,
           "hide": true,
           "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations \u0026 Alerts",
+          "name": "Annotations & Alerts",
           "query": {
             "group": "grafana",
             "kind": "DataQuery",
@@ -391,12 +391,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -590,12 +590,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -929,7 +929,7 @@
                     "options": {
                       "delimiter": "|",
                       "format": "regexp",
-                      "regExp": "/(?\u003cutm\u003e^([^{]+))/",
+                      "regExp": "/(?<utm>^([^{]+))/",
                       "source": "Metric"
                     }
                   }
@@ -965,7 +965,7 @@
           "description": "",
           "id": 107,
           "links": [],
-          "title": "count\u003cutm\u003e by fgt.utmaction",
+          "title": "count<utm> by fgt.utmaction",
           "transparent": true,
           "vizConfig": {
             "group": "barchart",
@@ -1174,12 +1174,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=rule.id_name%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=rule.id_name%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=rule.id_name%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=rule.id_name%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -2082,7 +2082,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.action,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.action,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -2308,7 +2308,7 @@
                     "options": {
                       "delimiter": "|",
                       "format": "regexp",
-                      "regExp": "/(?\u003cutm\u003e^([^{]+))/",
+                      "regExp": "/(?<utm>^([^{]+))/",
                       "source": "Metric"
                     }
                   }
@@ -2344,7 +2344,7 @@
           "description": "",
           "id": 185,
           "links": [],
-          "title": "count\u003cutm\u003e by fgt.utmaction",
+          "title": "count<utm> by fgt.utmaction",
           "transparent": true,
           "vizConfig": {
             "group": "barchart",
@@ -2481,7 +2481,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (rule.id_name,log.syslog.hostname) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (rule.id_name,log.syslog.hostname) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -2553,12 +2553,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=rule.id_name%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=rule.id_name%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=rule.id_name%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=rule.id_name%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -3067,7 +3067,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -3153,16 +3153,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -3271,7 +3271,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip:/24,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip:/24,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -3459,7 +3459,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| source.nat.ip:*\n| stats by (source.nat.ip,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| source.nat.ip:*\n| stats by (source.nat.ip,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -3545,16 +3545,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -3663,7 +3663,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -3749,16 +3749,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -3867,7 +3867,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip:/24,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip:/24,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -4055,7 +4055,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| destination.nat.ip:*\n| stats by (destination.nat.ip,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| destination.nat.ip:*\n| stats by (destination.nat.ip,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -4141,16 +4141,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -4259,7 +4259,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip,fgt.utmaction) count_uniq(destination.ip) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip,fgt.utmaction) count_uniq(destination.ip) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -4345,16 +4345,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -4548,7 +4548,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip,fgt.utmaction) count_uniq(network.transport_port) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip,fgt.utmaction) count_uniq(network.transport_port) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -4634,16 +4634,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -4752,7 +4752,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcreputation:*\n| stats by (fgt.srcreputation,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcreputation:*\n| stats by (fgt.srcreputation,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -4838,12 +4838,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcreputation%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcreputation%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcreputation%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcreputation%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -4978,7 +4978,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip,fgt.utmaction) count_uniq(source.ip) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip,fgt.utmaction) count_uniq(source.ip) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -5064,16 +5064,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -5182,7 +5182,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip,fgt.utmaction) count_uniq(network.transport_port) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip,fgt.utmaction) count_uniq(network.transport_port) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -5268,16 +5268,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -5386,7 +5386,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstreputation:*\n| stats by (fgt.dstreputation,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstreputation:*\n| stats by (fgt.dstreputation,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -5472,12 +5472,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstreputation%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstreputation%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstreputation%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstreputation%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -5612,7 +5612,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcname:*\n| stats by (fgt.srcname,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcname:*\n| stats by (fgt.srcname,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -5698,12 +5698,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -5811,7 +5811,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.user:*\n| stats by (fgt.user,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.user:*\n| stats by (fgt.user,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -5897,12 +5897,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.user%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.user%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.user%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.user%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -6010,7 +6010,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -6096,12 +6096,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthuser%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthuser%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthuser%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthuser%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -6209,7 +6209,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstname:*\n| stats by (fgt.dstname,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstname:*\n| stats by (fgt.dstname,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -6295,12 +6295,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -6408,7 +6408,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstuser:*\n| stats by (fgt.dstuser,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstuser:*\n| stats by (fgt.dstuser,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -6494,12 +6494,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstuser%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstuser%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstuser%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstuser%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -6607,7 +6607,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -6693,12 +6693,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthuser%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthuser%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthuser%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthuser%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -6806,7 +6806,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.devtype:*\n| stats by (fgt.devtype,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.devtype:*\n| stats by (fgt.devtype,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -6892,12 +6892,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.devtype%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.devtype%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.devtype%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.devtype%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -7005,7 +7005,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.authserver:*\n| stats by (fgt.authserver,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.authserver:*\n| stats by (fgt.authserver,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -7091,12 +7091,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.authserver%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.authserver%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.authserver%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.authserver%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -7204,7 +7204,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.unauthusersource:*\n| stats by (fgt.unauthusersource,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.unauthusersource:*\n| stats by (fgt.unauthusersource,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -7290,12 +7290,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthusersource%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthusersource%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthusersource%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthusersource%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -7403,7 +7403,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstdevtype:*\n| stats by (fgt.dstdevtype,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstdevtype:*\n| stats by (fgt.dstdevtype,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -7489,12 +7489,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstdevtype%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstdevtype%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstdevtype%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstdevtype%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -7602,7 +7602,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstauthserver:*\n| stats by (fgt.dstauthserver,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstauthserver:*\n| stats by (fgt.dstauthserver,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -7688,12 +7688,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstauthserver%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstauthserver%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstauthserver%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstauthserver%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -7801,7 +7801,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstunauthusersource:*\n| stats by (fgt.dstunauthusersource,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstunauthusersource:*\n| stats by (fgt.dstunauthusersource,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -7887,12 +7887,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthusersource%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthusersource%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthusersource%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthusersource%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -8000,7 +8000,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nnetwork.transport_port:in(\n    * | stats by (network.transport_port) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep network.transport_port\n)\n| stats by (network.transport_port) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nnetwork.transport_port:in(\n    * | stats by (network.transport_port) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep network.transport_port\n)\n| stats by (network.transport_port) sum(fgt.crscore) results",
                         "legendFormat": "{{network.transport_port}}",
                         "queryType": "statsRange"
                       },
@@ -8120,7 +8120,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nfgt.service:in(\n    * | stats by (fgt.service) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep fgt.service\n)\n| stats by (fgt.service) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nfgt.service:in(\n    * | stats by (fgt.service) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.service\n)\n| stats by (fgt.service) sum(fgt.crscore) results",
                         "legendFormat": "{{fgt.service}}",
                         "queryType": "statsRange"
                       },
@@ -8240,7 +8240,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} network.application:* ))\nnetwork.application:in(\n    * | stats by (network.application) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep network.application\n)\n| stats by (network.application) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} network.application:* ))\nnetwork.application:in(\n    * | stats by (network.application) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep network.application\n)\n| stats by (network.application) sum(fgt.crscore) results",
                         "legendFormat": "{{network.application}}",
                         "queryType": "statsRange"
                       },
@@ -8360,7 +8360,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.transport_port:*\n| stats by (network.transport_port,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.transport_port:*\n| stats by (network.transport_port,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -8446,12 +8446,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -8559,7 +8559,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.service,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.service,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -8645,12 +8645,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -8758,7 +8758,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.application:*\n| stats by (network.application,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.application:*\n| stats by (network.application,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -8844,12 +8844,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -8957,7 +8957,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.application:*\n| stats by (fgt.appcat,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.application:*\n| stats by (fgt.appcat,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -9043,12 +9043,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -9500,7 +9500,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.vwlid:*\n| stats by (fgt.vwlid,fgt.vwlname,log.syslog.hostname) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.vwlid:*\n| stats by (fgt.vwlid,fgt.vwlname,log.syslog.hostname) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -9664,7 +9664,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.shapingpolicyid:*\n| stats by (fgt.shapingpolicyid,fgt.shapingpolicyname,log.syslog.hostname) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.shapingpolicyid:*\n| stats by (fgt.shapingpolicyid,fgt.shapingpolicyname,log.syslog.hostname) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -10126,7 +10126,7 @@
                     "options": {
                       "delimiter": ",",
                       "format": "regexp",
-                      "regExp": "/vmrange=\"(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+?)\"/",
+                      "regExp": "/vmrange=\"(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+?)\"/",
                       "source": "Metric"
                     }
                   }
@@ -10208,7 +10208,7 @@
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -10279,7 +10279,7 @@
                     "options": {
                       "delimiter": ",",
                       "format": "regexp",
-                      "regExp": "/vmrange=\"(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+?)\"/",
+                      "regExp": "/vmrange=\"(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+?)\"/",
                       "source": "Metric"
                     }
                   }
@@ -10361,7 +10361,7 @@
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -10432,7 +10432,7 @@
                     "options": {
                       "delimiter": ",",
                       "format": "regexp",
-                      "regExp": "/vmrange=\"(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+?)\"/",
+                      "regExp": "/vmrange=\"(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+?)\"/",
                       "source": "Metric"
                     }
                   }
@@ -10514,7 +10514,7 @@
                   "color": "rgba(255,0,255,0.7)"
                 },
                 "filterValues": {
-                  "le": 1e-9
+                  "le": 1e-09
                 },
                 "legend": {
                   "show": true
@@ -10557,7 +10557,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (rule.id_name,log.syslog.hostname) sum(network.bytes) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (rule.id_name,log.syslog.hostname) sum(network.bytes) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -10629,12 +10629,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=rule.id_name%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=rule.id_name%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=rule.id_name%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=rule.id_name%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -10700,7 +10700,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.vwlid:*\n| stats by (fgt.vwlid,fgt.vwlname,log.syslog.hostname) sum(network.bytes) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.vwlid:*\n| stats by (fgt.vwlid,fgt.vwlname,log.syslog.hostname) sum(network.bytes) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -10804,12 +10804,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.vwlname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.vwlname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.vwlname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.vwlname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -10875,7 +10875,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.shapingpolicyid:*\n| stats by (fgt.shapingpolicyid,fgt.shapingpolicyname,log.syslog.hostname) sum(network.bytes) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.shapingpolicyid:*\n| stats by (fgt.shapingpolicyid,fgt.shapingpolicyname,log.syslog.hostname) sum(network.bytes) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -10979,12 +10979,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.shapingpolicyname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.shapingpolicyname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.shapingpolicyname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.shapingpolicyname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -11494,7 +11494,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nsource.ip:in(\n    * | stats by (source.ip) sum(network.bytes) results | sort by (results) desc | limit 10 | keep source.ip\n)\n| stats by (source.ip) sum(network.bytes) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nsource.ip:in(\n    * | stats by (source.ip) sum(network.bytes) results | filter -results:NaN | sort by (results) desc | limit 10 | keep source.ip\n)\n| stats by (source.ip) sum(network.bytes) results",
                         "legendFormat": "{{source.ip}}",
                         "queryType": "statsRange"
                       },
@@ -11614,7 +11614,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\ndestination.ip:in(\n    * | stats by (destination.ip) sum(network.bytes) results | sort by (results) desc | limit 10 | keep destination.ip\n)\n| stats by (destination.ip) sum(network.bytes) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\ndestination.ip:in(\n    * | stats by (destination.ip) sum(network.bytes) results | filter -results:NaN | sort by (results) desc | limit 10 | keep destination.ip\n)\n| stats by (destination.ip) sum(network.bytes) results",
                         "legendFormat": "{{destination.ip}}",
                         "queryType": "statsRange"
                       },
@@ -11679,16 +11679,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -11784,7 +11784,7 @@
                       "delimiter": ",",
                       "format": "regexp",
                       "keepTime": false,
-                      "regExp": "/^(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+)$/",
+                      "regExp": "/^(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+)$/",
                       "replace": false,
                       "source": "vmrange"
                     }
@@ -11983,7 +11983,7 @@
                       "delimiter": ",",
                       "format": "regexp",
                       "keepTime": false,
-                      "regExp": "/^(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+)$/",
+                      "regExp": "/^(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+)$/",
                       "replace": false,
                       "source": "vmrange"
                     }
@@ -12148,7 +12148,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (source.ip) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -12209,16 +12209,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -12285,7 +12285,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (source.ip:/24) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip:/24) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -12406,7 +12406,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| source.nat.ip:*\n| stats by (source.nat.ip) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| source.nat.ip:*\n| stats by (source.nat.ip) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -12467,16 +12467,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -12543,7 +12543,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (destination.ip) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -12604,16 +12604,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -12680,7 +12680,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (destination.ip:/24) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip:/24) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -12801,7 +12801,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| destination.nat.ip:*\n| stats by (destination.nat.ip) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| destination.nat.ip:*\n| stats by (destination.nat.ip) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -12862,16 +12862,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -12938,7 +12938,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (source.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -12999,16 +12999,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -13075,7 +13075,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (source.ip:/24) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip:/24) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -13196,7 +13196,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| source.nat.ip:*\n| stats by (source.nat.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| source.nat.ip:*\n| stats by (source.nat.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -13257,16 +13257,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -13333,7 +13333,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (destination.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -13394,16 +13394,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -13470,7 +13470,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (destination.ip:/24) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip:/24) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -13591,7 +13591,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| destination.nat.ip:*\n| stats by (destination.nat.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| destination.nat.ip:*\n| stats by (destination.nat.ip) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -13652,16 +13652,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -13728,7 +13728,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| stats by (source.ip)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -13789,16 +13789,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -13865,7 +13865,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| stats by (source.ip:/24)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (source.ip:/24)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -13986,7 +13986,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| source.nat.ip:*\n| stats by (source.nat.ip) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| source.nat.ip:*\n| stats by (source.nat.ip) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -14047,16 +14047,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -14123,7 +14123,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| stats by (destination.ip)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -14184,16 +14184,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -14260,7 +14260,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| stats by (destination.ip:/24)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (destination.ip:/24)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -14381,7 +14381,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| destination.nat.ip:*\n| stats by (destination.nat.ip)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| destination.nat.ip:*\n| stats by (destination.nat.ip)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -14442,16 +14442,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -14518,7 +14518,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.user:* ))\nfgt.user:in(\n    * | stats by (fgt.user) sum(network.bytes) results | sort by (results) desc | limit 10 | keep fgt.user\n)\n| stats by (fgt.user) sum(network.bytes) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.user:* ))\nfgt.user:in(\n    * | stats by (fgt.user) sum(network.bytes) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.user\n)\n| stats by (fgt.user) sum(network.bytes) results",
                         "legendFormat": "{{fgt.user}}",
                         "queryType": "statsRange"
                       },
@@ -14638,7 +14638,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.dstuser:* ))\nfgt.dstuser:in(\n    * | stats by (fgt.dstuser) sum(network.bytes) results | sort by (results) desc | limit 10 | keep fgt.dstuser\n)\n| stats by (fgt.dstuser) sum(network.bytes) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.dstuser:* ))\nfgt.dstuser:in(\n    * | stats by (fgt.dstuser) sum(network.bytes) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.dstuser\n)\n| stats by (fgt.dstuser) sum(network.bytes) results",
                         "legendFormat": "{{fgt.dstuser}}",
                         "queryType": "statsRange"
                       },
@@ -14703,16 +14703,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -14808,7 +14808,7 @@
                       "delimiter": ",",
                       "format": "regexp",
                       "keepTime": false,
-                      "regExp": "/^(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+)$/",
+                      "regExp": "/^(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+)$/",
                       "replace": false,
                       "source": "vmrange"
                     }
@@ -15007,7 +15007,7 @@
                       "delimiter": ",",
                       "format": "regexp",
                       "keepTime": false,
-                      "regExp": "/^(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+)$/",
+                      "regExp": "/^(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+)$/",
                       "replace": false,
                       "source": "vmrange"
                     }
@@ -15172,7 +15172,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.user:*\n| stats by (fgt.user) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.user:*\n| stats by (fgt.user) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -15233,16 +15233,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -15309,7 +15309,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser:/24) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser:/24) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -15370,16 +15370,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -15446,7 +15446,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.group:*\n| stats by (fgt.group) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.group:*\n| stats by (fgt.group) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -15507,16 +15507,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -15583,7 +15583,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.dstuser:*\n| stats by (fgt.dstuser) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstuser:*\n| stats by (fgt.dstuser) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -15644,16 +15644,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -15720,7 +15720,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -15781,16 +15781,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -15857,7 +15857,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.dstgroup:*\n| stats by (fgt.dstgroup) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstgroup:*\n| stats by (fgt.dstgroup) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -15918,16 +15918,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -15994,7 +15994,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.user:*\n| stats by (fgt.user) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.user:*\n| stats by (fgt.user) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -16055,16 +16055,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -16131,7 +16131,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -16192,16 +16192,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -16268,7 +16268,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.group:*\n| stats by (fgt.group) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.group:*\n| stats by (fgt.group) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -16329,16 +16329,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -16405,7 +16405,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.dstuser:*\n| stats by (fgt.dstuser) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstuser:*\n| stats by (fgt.dstuser) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -16466,16 +16466,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -16542,7 +16542,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -16603,16 +16603,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -16679,7 +16679,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| fgt.dstgroup:*\n| stats by (fgt.dstgroup) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstgroup:*\n| stats by (fgt.dstgroup) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -16740,16 +16740,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -16816,7 +16816,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| fgt.user:*\n| stats by (fgt.user) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.user:*\n| stats by (fgt.user) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -16877,16 +16877,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -16953,7 +16953,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.unauthuser:*\n| stats by (fgt.unauthuser) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -17014,16 +17014,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -17090,7 +17090,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| fgt.group:*\n| stats by (fgt.group) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.group:*\n| stats by (fgt.group) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -17151,16 +17151,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -17227,7 +17227,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| fgt.dstuser:*\n| stats by (fgt.dstuser) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstuser:*\n| stats by (fgt.dstuser) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -17288,16 +17288,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -17364,7 +17364,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstunauthuser:*\n| stats by (fgt.dstunauthuser) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -17425,16 +17425,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -17501,7 +17501,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| fgt.dstgroup:*\n| stats by (fgt.dstgroup) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstgroup:*\n| stats by (fgt.dstgroup) quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -17562,16 +17562,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -17638,7 +17638,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nnetwork.transport_port:in(\n    * | stats by (network.transport_port) sum(network.bytes) results | sort by (results) desc | limit 10 | keep network.transport_port\n)\n| stats by (network.transport_port) sum(network.bytes) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nnetwork.transport_port:in(\n    * | stats by (network.transport_port) sum(network.bytes) results | filter -results:NaN | sort by (results) desc | limit 10 | keep network.transport_port\n)\n| stats by (network.transport_port) sum(network.bytes) results",
                         "legendFormat": "{{network.transport_port}}",
                         "queryType": "statsRange"
                       },
@@ -17758,7 +17758,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} network.application:* ))\nnetwork.application:in(\n    * | stats by (network.application) sum(network.bytes) results | sort by (results) desc | limit 10 | keep network.application\n)\n| stats by (network.application) sum(network.bytes) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} network.application:* ))\nnetwork.application:in(\n    * | stats by (network.application) sum(network.bytes) results | filter -results:NaN | sort by (results) desc | limit 10 | keep network.application\n)\n| stats by (network.application) sum(network.bytes) results",
                         "legendFormat": "{{network.application}}",
                         "queryType": "statsRange"
                       },
@@ -17912,7 +17912,7 @@
                       "delimiter": ",",
                       "format": "regexp",
                       "keepTime": false,
-                      "regExp": "/^(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+)$/",
+                      "regExp": "/^(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+)$/",
                       "replace": false,
                       "source": "vmrange"
                     }
@@ -18111,7 +18111,7 @@
                       "delimiter": ",",
                       "format": "regexp",
                       "keepTime": false,
-                      "regExp": "/^(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+)$/",
+                      "regExp": "/^(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+)$/",
                       "replace": false,
                       "source": "vmrange"
                     }
@@ -18276,7 +18276,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (network.transport_port) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (network.transport_port) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -18337,12 +18337,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -18408,7 +18408,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (fgt.service) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.service) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -18469,12 +18469,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -18540,7 +18540,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| network.application:*\n| stats by (network.application) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.application:*\n| stats by (network.application) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -18601,12 +18601,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -18672,7 +18672,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (fgt.appcat) sum(network.bytes) sum\n| sort by (sum) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.appcat) sum(network.bytes) sum\n| filter -sum:NaN\n| sort by (sum) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -18733,12 +18733,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -18804,7 +18804,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (network.transport_port) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (network.transport_port) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -18865,12 +18865,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -18936,7 +18936,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (fgt.service) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.service) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -18997,12 +18997,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -19188,7 +19188,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| network.application:*\n| stats by (network.application) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.application:*\n| stats by (network.application) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -19249,12 +19249,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -19320,7 +19320,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.bytes:*\n| stats by (fgt.appcat) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.appcat) quantile(0.9,network.bytes) p90, avg(network.bytes) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -19381,12 +19381,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -19452,7 +19452,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| stats by (network.transport_port)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (network.transport_port)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -19513,12 +19513,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -19584,7 +19584,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| stats by (fgt.service)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.service)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -19645,12 +19645,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -19716,7 +19716,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| network.application:*\n| stats by (network.application)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| network.application:*\n| stats by (network.application)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -19777,12 +19777,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.application%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -19848,7 +19848,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.duration:*\n| stats by (fgt.appcat)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| sort by (avg) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| stats by (fgt.appcat)  quantile(0.9,fgt.duration) p90, avg(fgt.duration) avg\n| filter -avg:NaN\n| sort by (avg) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -19909,12 +19909,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.appcat%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -19980,7 +19980,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nfgt.service:in(\n    * | stats by (fgt.service) sum(network.bytes) results | sort by (results) desc | limit 10 | keep fgt.service\n)\n| stats by (fgt.service) sum(network.bytes) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nfgt.service:in(\n    * | stats by (fgt.service) sum(network.bytes) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.service\n)\n| stats by (fgt.service) sum(network.bytes) results",
                         "legendFormat": "{{fgt.service}}",
                         "queryType": "statsRange"
                       },
@@ -20134,7 +20134,7 @@
                       "delimiter": ",",
                       "format": "regexp",
                       "keepTime": false,
-                      "regExp": "/^(?\u003cvmrange_start\u003e.+?)\\.\\.\\.(?\u003cvmrange_end\u003e.+)$/",
+                      "regExp": "/^(?<vmrange_start>.+?)\\.\\.\\.(?<vmrange_end>.+)$/",
                       "replace": false,
                       "source": "vmrange"
                     }
@@ -20484,16 +20484,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -20641,16 +20641,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -21033,16 +21033,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -21237,16 +21237,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -21629,16 +21629,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.nat.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -21953,16 +21953,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -22157,16 +22157,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=source.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -22361,12 +22361,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcreputation%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcreputation%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcreputation%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcreputation%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -22587,16 +22587,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -22791,16 +22791,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -22995,12 +22995,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstreputation%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstreputation%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstreputation%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstreputation%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -23440,16 +23440,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -23597,12 +23597,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -23796,12 +23796,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.user%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.user%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.user%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.user%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -23995,12 +23995,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthuser%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthuser%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthuser%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthuser%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -24194,12 +24194,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -24393,12 +24393,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstuser%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstuser%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstuser%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstuser%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -24592,12 +24592,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthuser%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthuser%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthuser%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthuser%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -24791,12 +24791,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.group%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.group%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.group%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.group%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -24990,12 +24990,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.authserver%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.authserver%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.authserver%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.authserver%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -25189,12 +25189,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthusersource%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthusersource%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.unauthusersource%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.unauthusersource%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -25388,12 +25388,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstgroup%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstgroup%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstgroup%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstgroup%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -25587,12 +25587,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstauthserver%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstauthserver%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstauthserver%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstauthserver%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -25786,12 +25786,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthusersource%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthusersource%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstunauthusersource%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstunauthusersource%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -26105,12 +26105,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -26304,12 +26304,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.osname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.osname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.osname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.osname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -26503,12 +26503,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srchwvendor%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srchwvendor%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srchwvendor%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srchwvendor%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -26702,12 +26702,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -26901,12 +26901,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstosname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstosname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstosname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstosname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -27100,12 +27100,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dsthwvendor%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dsthwvendor%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dsthwvendor%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dsthwvendor%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -27299,12 +27299,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.devtype%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.devtype%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.devtype%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.devtype%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -27498,12 +27498,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcswversion%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcswversion%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcswversion%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcswversion%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -27697,12 +27697,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcfamily%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcfamily%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcfamily%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcfamily%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -27896,12 +27896,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstdevtype%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstdevtype%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstdevtype%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstdevtype%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -28095,12 +28095,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstswversion%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstswversion%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstswversion%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstswversion%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -28294,12 +28294,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstfamily%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstfamily%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstfamily%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstfamily%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -28407,7 +28407,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nsource.ip:in(\n    * | stats by (source.ip) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep source.ip\n)\n| stats by (source.ip) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\nsource.ip:in(\n    * | stats by (source.ip) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep source.ip\n)\n| stats by (source.ip) sum(fgt.crscore) results",
                         "legendFormat": "{{source.ip}}",
                         "queryType": "statsRange"
                       },
@@ -28527,7 +28527,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\ndestination.ip:in(\n    * | stats by (destination.ip) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep destination.ip\n)\n| stats by (destination.ip) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} ))\ndestination.ip:in(\n    * | stats by (destination.ip) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep destination.ip\n)\n| stats by (destination.ip) sum(fgt.crscore) results",
                         "legendFormat": "{{destination.ip}}",
                         "queryType": "statsRange"
                       },
@@ -28647,7 +28647,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.user:* ))\nfgt.user:in(\n    * | stats by (fgt.user) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep fgt.user\n)\n| stats by (fgt.user) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.user:* ))\nfgt.user:in(\n    * | stats by (fgt.user) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.user\n)\n| stats by (fgt.user) sum(fgt.crscore) results",
                         "legendFormat": "{{fgt.user}}",
                         "queryType": "statsRange"
                       },
@@ -28767,7 +28767,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.dstuser:* ))\nfgt.dstuser:in(\n    * | stats by (fgt.dstuser) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep fgt.dstuser\n)\n| stats by (fgt.dstuser) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.dstuser:* ))\nfgt.dstuser:in(\n    * | stats by (fgt.dstuser) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.dstuser\n)\n| stats by (fgt.dstuser) sum(fgt.crscore) results",
                         "legendFormat": "{{fgt.dstuser}}",
                         "queryType": "statsRange"
                       },
@@ -28887,7 +28887,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.srcname:* ))\nfgt.srcname:in(\n    * | stats by (fgt.srcname) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep fgt.srcname\n)\n| stats by (fgt.srcname) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.srcname:* ))\nfgt.srcname:in(\n    * | stats by (fgt.srcname) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.srcname\n)\n| stats by (fgt.srcname) sum(fgt.crscore) results",
                         "legendFormat": "{{fgt.srcname}}",
                         "queryType": "statsRange"
                       },
@@ -29007,7 +29007,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.dstname:* ))\nfgt.dstname:in(\n    * | stats by (fgt.dstname) sum(fgt.crscore) results | sort by (results) desc | limit 10 | keep fgt.dstname\n)\n| stats by (fgt.dstname) sum(fgt.crscore) results",
+                        "expr": "options(global_filter=( _stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020} fgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw} fgt.dstname:* ))\nfgt.dstname:in(\n    * | stats by (fgt.dstname) sum(fgt.crscore) results | filter -results:NaN | sort by (results) desc | limit 10 | keep fgt.dstname\n)\n| stats by (fgt.dstname) sum(fgt.crscore) results",
                         "legendFormat": "{{destination.ip}}",
                         "queryType": "statsRange"
                       },
@@ -29072,16 +29072,16 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=destination.ip%7C%21%3D%7C${__data.fields[0]}"
                     },
                     {
                       "targetBlank": true,
-                      "title": "Virus Total 🦠",
+                      "title": "Virus Total \ud83e\udda0",
                       "url": "https://www.virustotal.com/gui/ip-address/${__data.fields[0]}"
                     }
                   ],
@@ -29143,7 +29143,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcname:*\n| stats by (fgt.srcname,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcname:*\n| stats by (fgt.srcname,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -29229,12 +29229,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -29342,7 +29342,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.osname:*\n| stats by (fgt.osname,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.osname:*\n| stats by (fgt.osname,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -29428,12 +29428,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.osname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.osname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.osname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.osname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -29541,7 +29541,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srchwvendor:*\n| stats by (fgt.srchwvendor,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srchwvendor:*\n| stats by (fgt.srchwvendor,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -29627,12 +29627,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srchwvendor%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srchwvendor%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srchwvendor%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srchwvendor%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -29740,7 +29740,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstname:*\n| stats by (fgt.dstname,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstname:*\n| stats by (fgt.dstname,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -29826,12 +29826,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -29939,7 +29939,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstosname:*\n| stats by (fgt.dstosname,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstosname:*\n| stats by (fgt.dstosname,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -30025,12 +30025,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstosname%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstosname%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstosname%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstosname%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -30138,7 +30138,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dsthwvendor:*\n| stats by (fgt.dsthwvendor,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dsthwvendor:*\n| stats by (fgt.dsthwvendor,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -30224,12 +30224,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dsthwvendor%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dsthwvendor%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dsthwvendor%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dsthwvendor%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -30337,7 +30337,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.devtype:*\n| stats by (fgt.devtype,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.devtype:*\n| stats by (fgt.devtype,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -30423,12 +30423,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.devtype%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.devtype%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.devtype%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.devtype%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -30536,7 +30536,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcswversion:*\n| stats by (fgt.srcswversion,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcswversion:*\n| stats by (fgt.srcswversion,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -30622,12 +30622,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcswversion%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcswversion%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcswversion%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcswversion%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -30735,7 +30735,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcfamily:*\n| stats by (fgt.srcfamily,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.srcfamily:*\n| stats by (fgt.srcfamily,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -30821,12 +30821,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcfamily%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcfamily%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.srcfamily%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.srcfamily%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -30934,7 +30934,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstdevtype:*\n| stats by (fgt.dstdevtype,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstdevtype:*\n| stats by (fgt.dstdevtype,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -31020,12 +31020,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstdevtype%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstdevtype%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstdevtype%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstdevtype%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -31133,7 +31133,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstswversion:*\n| stats by (fgt.dstswversion,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstswversion:*\n| stats by (fgt.dstswversion,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -31219,12 +31219,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstswversion%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstswversion%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstswversion%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstswversion%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -31332,7 +31332,7 @@
                       "kind": "DataQuery",
                       "spec": {
                         "editorMode": "code",
-                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstfamily:*\n| stats by (fgt.dstfamily,fgt.utmaction) sum(fgt.crscore) results\n| sort by (results) desc\n| limit 10",
+                        "expr": "_stream:{log.syslog.hostname in (${firewall:doublequote}),fgt.vd in (${vdom:doublequote}),fgt.type=${type:doublequote},fgt.subtype=${subtype:doublequote},fgt.policytype=${policytype:doublequote},network.direction in (${direction:doublequote}),fgt.logid!=0000000020}\nfgt.action:in(${action:doublequote}) ${Logsql:raw} ${crscore:raw}\n| fgt.dstfamily:*\n| stats by (fgt.dstfamily,fgt.utmaction) sum(fgt.crscore) results\n| filter -results:NaN\n| sort by (results) desc\n| limit 10",
                         "queryType": "stats"
                       },
                       "version": "v0"
@@ -31418,12 +31418,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstfamily%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstfamily%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.dstfamily%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.dstfamily%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -31804,12 +31804,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=network.transport_port%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {
@@ -32003,12 +32003,12 @@
                   "links": [
                     {
                       "targetBlank": false,
-                      "title": "Filter for 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
+                      "title": "Filter for \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%3D%7C${__data.fields[0]}"
                     },
                     {
-                      "title": "Filter out 🔍",
-                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}\u0026var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
+                      "title": "Filter out \ud83d\udd0d",
+                      "url": "/d/${__dashboard.uid}/${__dashboard.slug}?${__all_variables}&var-Filters=fgt.service%7C%21%3D%7C${__data.fields[0]}"
                     }
                   ],
                   "thresholds": {


### PR DESCRIPTION
## Summary
- Bytes/risk score barcharts (95 panels): remove pre-stats metric field filter (`| network.bytes:*`, `| fgt.duration:*`), insert `| filter -<sort_field>:NaN` after stats and before sort. Secondary field filters preserved.
- Bytes/risk score timeseries options() panels (16 panels): insert `| filter -results:NaN` inside subquery before `| sort by (results)`.
- 7 histogram/complex barchart panels and 3 simple timeseries without sort fields left unchanged.

## Test plan
- [ ] Verify barcharts in bytes tab render without NaN rows
- [ ] Verify barcharts in risk score tab render without NaN rows
- [ ] Verify timeseries top-10 subqueries still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)